### PR TITLE
Fix maps root not found bug when creating submission docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ x-nuplan-volumes: &x-nuplan-volumes
   volumes:
     - "$NUPLAN_DATA_ROOT:/data/sets/nuplan:rw"
     - "$NUPLAN_EXP_ROOT:/data/exp/nuplan:rw"
+    - "$NUPLAN_MAPS_ROOT:/data/sets/nuplan/maps:rw"
 
 
 x-nuplan-maps: &x-nuplan-maps


### PR DESCRIPTION
**Changes**
- **docker-compose.yml**: added a mapping for _NUPLAN_MAPS_ROOT_ while creating simulation docker, a fix for #236