### PR TITLE
Replace double quotes in query with single ones

### DIFF
--- a/nuplan/database/nuplan_db/nuplan_scenario_queries.py
+++ b/nuplan/database/nuplan_db/nuplan_scenario_queries.py
@@ -609,9 +609,9 @@ def get_traffic_light_status_for_lidarpc_token_from_db(
     :return: The traffic light status data associated with the given lidar_pc.
     """
     query = """
-        SELECT  CASE WHEN tl.status == "green" THEN 0
-                     WHEN tl.status == "yellow" THEN 1
-                     WHEN tl.status == "red" THEN 2
+        SELECT  CASE WHEN tl.status == 'green' THEN 0
+                     WHEN tl.status == 'yellow' THEN 1
+                     WHEN tl.status == 'red' THEN 2
                      ELSE 3
                 END AS status,
                 tl.lane_connector_id,


### PR DESCRIPTION
When trying to generate features from the dataset, an error occurs as below:
```python
File "/home/shlee625/nuplan-devkit/nuplan/database/nuplan_db/nuplan_scenario_queries.py", line 625, in get_traffic_light_status_for_lidarpc_token_from_db
  for row in execute_many(query, (bytearray.fromhex(token),), log_file):
File /home/shlee625/nuplan-devkit/nuplan/database/nuplan_db/query_session.py", line 21, in execute_many
  cursor.execute(query_text, query_parameters)
sqlite3.OperationalError: no such column: "green" - should this be a string literal in single-quotes?
```
Indeed, the query includes double quotes, which should be single quotes ([code](https://github.com/motional/nuplan-devkit/blob/master/nuplan/database/nuplan_db/nuplan_scenario_queries.py#L611-L623)). When replacing them, the error has been resolved.